### PR TITLE
psr/log through Composer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "NGS/PSR3"]
-	path = NGS/PSR3
-	url = https://github.com/php-fig/log.git

--- a/composer.json
+++ b/composer.json
@@ -3,13 +3,14 @@
     "type": "library",
     "keywords": ["DSL", "DDD"],
     "description": "DSL platform PHP client library",
-    "homepage": "https://dsl-platform.com",
+    "homepage": "https://dsl-platform.com/",
     "license": "BSD-3-Clause",
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.8",
         "lib-curl": "*",
-        "ext-SimpleXML": "*"
+        "ext-SimpleXML": "*",
+        "psr/log": "~1.0"
     },
 
     "autoload": {


### PR DESCRIPTION
We are already using Composer for resolving dependencies, so it makes no sense to keep the psr/log as a submodule.
